### PR TITLE
Pagination Support and UI Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,21 @@ To install the plugin, follow these instructions.
 
 
 ## Configuring Craftnet CP
-Create a ``craftnet-cp.php`` file in ``/path/to/project/config`` with an array called ``plugins``, which contains ``handle => label`` for each of your plugins.
+
+You can manage the following settings in your `craftnet-cp.php` file:
+
+- username (optional, also available as setting in CP)
+- token (optional, also available as setting in CP)
+- plugins (required, contains `handle => label` for each of your plugins.)
+- displayNotes (optional, displays notes below plugin license info)
 
     <?php return [
+        'username' => 'you@myawesomeplugins.com',
+        'token' => '5tmukfu4x2ld8xm1619oJy8klw17fvDsXsDDft8nk
         'plugins' => [
             'plugin-handle' => 'Plugin Label',
-        ]
+        ],
+        'displayNotes' => true
     ];
 
 ## Functionality

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "craftcms/cms": "^3.0.0",
-        "barrelstrength/craftnet-php": "0.0.1"
+        "barrelstrength/craftnet-php": "1.0.0 "
 
     },
     "autoload": {

--- a/src/CraftnetCp.php
+++ b/src/CraftnetCp.php
@@ -86,6 +86,7 @@ class CraftnetCp extends Plugin
             UrlManager::EVENT_REGISTER_CP_URL_RULES,
             function (RegisterUrlRulesEvent $event) {
                 $event->rules['craftnet-cp'] = 'craftnet-cp/license/index';
+                $event->rules['craftnet-cp/index'] = 'craftnet-cp/license/index';
                 $event->rules['craftnet-cp/generate'] = 'craftnet-cp/license/generate';
                 $event->rules['craftnet-cp/list'] = 'craftnet-cp/license/list';
             }

--- a/src/CraftnetCp.php
+++ b/src/CraftnetCp.php
@@ -159,4 +159,21 @@ class CraftnetCp extends Plugin
             ]
         );
     }
+
+    public function getCpNavItem()
+    {
+        $parent = parent::getCpNavItem();
+
+        $navigation['subnav']['generate'] = [
+            'label' => Craft::t('craftnet-cp', 'Generate'),
+            'url' => 'craftnet-cp/index'
+        ];
+
+        $navigation['subnav']['list'] = [
+            'label' => Craft::t('craftnet-cp', 'Licenses'),
+            'url' => 'craftnet-cp/list'
+        ];
+
+        return array_merge($parent, $navigation);
+    }
 }

--- a/src/controllers/LicenseController.php
+++ b/src/controllers/LicenseController.php
@@ -38,11 +38,13 @@ use craft\web\Controller;
  */
 class LicenseController extends Controller
 {
-
-    public function actionIndex() {
+    public function actionIndex()
+    {
         $plugins = CraftnetCp::$plugin->getSettings()->plugins;
-        return $this->renderTemplate('craftnet-cp/index', ['plugins' => $plugins]);
 
+        return $this->renderTemplate('craftnet-cp/index', [
+            'plugins' => $plugins
+        ]);
     }
 
     // Public Methods

--- a/src/controllers/LicenseController.php
+++ b/src/controllers/LicenseController.php
@@ -81,19 +81,28 @@ class LicenseController extends Controller
     /**
      * @return mixed
      */
-    public function actionList()
+    public function actionList(int $page = 1)
     {
+        if ($requestedPage = Craft::$app->request->getBodyParam('page')) {
+            $page = (int)$requestedPage;
+        }
+
         $username = CraftnetCp::$plugin->getSettings()->username;
         $apiKey = CraftnetCp::$plugin->getSettings()->token;
         $client = new CraftnetClient($username, $apiKey);
 
-        $response = $client->pluginLicenses->get();
+        $response = $client->pluginLicenses->get([
+            'page' => $page
+        ]);
 
         $pluginLicenses = $response->getBody()->getContents();
 
         $results = json_decode($pluginLicenses);
-        return $this->renderTemplate('craftnet-cp/list', ['data' => $results]);
 
-
+        return $this->renderTemplate('craftnet-cp/list', [
+            'data' => $results,
+            'page' => $page,
+            'displayNotes' => CraftnetCp::$plugin->getSettings()->displayNotes
+        ]);
     }
 }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -43,6 +43,8 @@ class Settings extends Model
 
     public $plugins = [];
 
+    public $displayNotes = false;
+
     // Public Methods
     // =========================================================================
 

--- a/src/templates/index.twig
+++ b/src/templates/index.twig
@@ -16,93 +16,132 @@
 {% extends "_layouts/cp" %}
 {% import "_includes/forms" as forms %}
 
-{% set title = "Create new license - Craft ID" %}
-
-{% set tabs = {
-    'generate' : {
-        label: 'Generate',
-        url: url('craftnet-cp')
-    },
-    'list' : {
-        label: 'List',
-        url: url('craftnet-cp') ~ '/list'
-    }
-} %}
+{% set title = "Create a new license" %}
+{% set selectedSubnavItem = 'generate' %}
 
 {% set content %}
     <form method="post" data-saveshortcut data-confirm-unload action="{{ actionUrl('craftnet-cp/license/generate') }}">
         {{ csrfInput() }}
         {{ redirectInput('craftnet-cp') }}
 
-        <div class="field" id="name-field">
-            <div class="heading">
-                <label id="name-label" class="required" for="email">{{ 'Email' }}</label>
-            </div>
-            <div class="input ltr">
-                <input class="text fullwidth" type="email" id="email" name="email" autofocus="" autocomplete="off" required="required">
-            </div>
-        </div>
-
-        <div class="field" id="name-field">
-            <div class="heading">
-                <label id="name-label" class="required" for="title">{{ 'Edition' }}</label>
-            </div>
-            <div class="input ltr">
-                <input class="text fullwidth" type="text" id="title" name="edition" value="standard" readonly autofocus="" autocomplete="off" required="required">
-            </div>
-        </div>
-
-        <div class="field first" id="group-field">
-            <div class="heading">
-                <label id="group-label" class="required" for="group">Plugin</label>
-            </div>
-            <div class="input ltr">
-                <div class="select">
-                    <select id="group" name="handle" required>
-                        <option value="" selected="" disabled>---</option>
-                        {% for handle, label in plugins %}
-                            <option value="{{ handle }}">{{ label }}</option>
-                        {% endfor %}
-                    </select>
-                </div>
-            </div>
-        </div>
-
-        {{ forms.lightswitchField({
-            label: 'Whether the license should be expirable ',
-            id: 'expirable',
-            name: 'expirable'
-
+        {{ forms.textField({
+            label: 'Email'|t('craftnet-cp'),
+            instructions: 'The Craft ID email to assign the license'|t('craftnet-cp'),
+            id: 'email',
+            name: 'email',
+            value: '',
+            first: true,
+            required: true
         }) }}
 
-        <div class="field" id="name-field">
-            <div class="heading">
-                <label id="name-label" for="notes">{{ 'Notes' }}</label>
-            </div>
-            <div class="input ltr">
-                <input class="text fullwidth" type="text" id="notes" name="notes" autofocus="" autocomplete="off">
-            </div>
-        </div>
+        {{ forms.textField({
+            label: 'Edition'|t('craftnet-cp'),
+            instructions: 'The edition of the plugin license'|t('craftnet-cp'),
+            id: 'edition',
+            name: 'edition',
+            value: 'standard',
+            required: true,
+            readonly: true
+        }) }}
 
-        <div class="field" id="name-field">
-            <div class="heading">
-                <label id="name-label" for="privateNotes">{{ 'Private notes' }}</label>
-            </div>
-            <div class="input ltr">
-                <input class="text fullwidth" type="text" id="privateNotes" name="privateNotes" autofocus="" autocomplete="off">
-            </div>
-        </div>
+        {% set pluginOptions = {} %}
+        {% set pluginOptions = pluginOptions|merge([{
+            'label': 'Select a plugin...'|t('craftnet-cp'),
+            'value': ''
+        }]) %}
 
-        <div class="field" id="name-field">
-            <div class="heading">
-                <label id="name-label" for="count">{{ 'Number of licenses' }}</label>
-            </div>
-            <div class="input ltr">
-                <input class="text fullwidth" value="1" min="1" type="number" id="count" name="count" autofocus="" autocomplete="off">
-            </div>
-        </div>
+        {% for handle, label in plugins %}
+            {% set pluginOptions = pluginOptions|merge([{
+                'label': label,
+                'value': handle
+            }]) %}
+        {% endfor %}
+
+        {{ forms.selectField({
+            id: "handle",
+            name: "handle",
+            label: "Plugin"|t('craftnet-cp'),
+            required: true,
+            options: pluginOptions,
+            value: ''
+        }) }}
+
+        {{ forms.selectField({
+            id: "count",
+            name: "count",
+            label: "Number of Licenses"|t('craftnet-cp'),
+            instructions: "The number of licenses you wish to create for this user."|t('craftnet-cp'),
+            required: true,
+            options: [
+                {
+                    label: "1",
+                    value: 1,
+                },
+                {
+                    label: "2",
+                    value: 2,
+                },
+                {
+                    label: "3",
+                    value: 3,
+                },
+                {
+                    label: "4",
+                    value: 4,
+                },
+                {
+                    label: "5",
+                    value: 5,
+                },
+                {
+                    label: "6",
+                    value: 6,
+                },
+                {
+                    label: "7",
+                    value: 7,
+                },
+                {
+                    label: "8",
+                    value: 8,
+                },
+                {
+                    label: "9",
+                    value: 9,
+                },
+                {
+                    label: "10",
+                    value: 10,
+                },
+                {
+                    label: "11",
+                    value: 11,
+                }
+            ],
+            value: ''
+        }) }}
+
+        {{ forms.lightswitchField({
+            label: 'Expirable'|t('craftnet-cp'),
+            instructions: 'Whether the license should be expirable.'|t('craftnet-cp'),
+            id: 'expirable',
+            name: 'expirable'
+        }) }}
+
+        {{ forms.textareaField({
+            label: 'Notes'|t('craftnet-cp'),
+            instructions: 'Notes that will display to the license holder.'|t('craftnet-cp'),
+            id: 'notes',
+            name: 'notes'
+        }) }}
+
+        {{ forms.textareaField({
+            label: 'Private Notes'|t('craftnet-cp'),
+            instructions: 'Notes that will only be visible to the plugin developer (theoretically).'|t('craftnet-cp'),
+            id: 'privateNotes',
+            name: 'privateNotes'
+        }) }}
 
         <input type="submit" class="btn submit" value="{{ 'Generate' }}">
-
     </form>
 {% endset %}

--- a/src/templates/list.twig
+++ b/src/templates/list.twig
@@ -16,21 +16,40 @@
 {% extends "_layouts/cp" %}
 {% import "_includes/forms" as forms %}
 
-{% set title = "Plugin licenses - Craft ID" %}
+{% set title = "Plugin licenses (" ~ data.total ~ ")" %}
+{% set selectedSubnavItem = 'list' %}
 
-{% set tabs = {
-    'generate' : {
-        label: 'Generate',
-        url: url('craftnet-cp')
-    },
-    'list' : {
-        label: 'List',
-        url: url('craftnet-cp') ~ '/list'
-    }
-} %}
 {% set selectedTab = 'list' %}
 
-{% set content %}
+{% block actionButton %}
+
+    {% set pages = [] %}
+    {% for i in 1..data.totalPages %}
+        {% set pages = pages|merge([{
+            'label': i,
+            'value': i
+        }]) %}
+    {% endfor %}
+
+    <form method="post" data-saveshortcut data-confirm-unload>
+        <input type="hidden" name="action" value="craftnet-cp/license/list">
+        {{ csrfInput() }}
+
+        {{ forms.select({
+            id: "page",
+            name: "page",
+            label: "Page"|t('craftnet-cp'),
+            options: pages,
+            value: page
+        }) }}
+
+        <input type="submit" class="btn submit" value="{{ 'Update' }}">
+
+    </form>
+
+{% endblock %}
+
+{% block content %}
     {% if data.licenses|length %}
     {% for handle, licenses in data.licenses|group('pluginHandle') %}
         <h2>{{ handle }}</h2>
@@ -51,6 +70,11 @@
                     <td data-title="email"><code>{{ sale.key }}</code></td>
                     <td data-title="date">{{ sale.dateCreated }}</td>
                 </tr>
+                {% if displayNotes %}
+                    <tr>
+                       <td colspan="5" class="light">{{ "Notes:"|t('craftnet-cp') }}: {{ sale.notes }}</td>
+                    </tr>
+                {% endif %}
             {% endfor %}
             </tbody>
         </table>
@@ -60,4 +84,4 @@
             {{ 'No sales found' }}
         </div>
     {% endif %}
-{% endset %}
+{% endblock %}

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -16,16 +16,19 @@
 {% import "_includes/forms" as forms %}
 
 {{ forms.textField({
-    label: 'id.craftcms.com API token',
-    instructions: 'Generate your token <a href="https://id.craftcms.com/developer/settings" target="_blank" rel="noopener">here</a>',
-    id: 'token',
-    name: 'token',
-    value: settings['token']})
-}}
-
-{{ forms.textField({
-    label: 'Your id.craftcms.com username',
+    label: 'Username',
+    instructions: 'Your id.craftcms.com username',
     id: 'username',
     name: 'username',
-    value: settings['username']})
-}}
+    value: settings['username'],
+    first: true
+}) }}
+
+{{ forms.textField({
+    label: 'API token',
+    instructions: 'Generate your Craft ID API token <a href="https://id.craftcms.com/developer/settings" target="_blank" rel="noopener">here</a>',
+    id: 'token',
+    name: 'token',
+    value: settings['token']
+}) }}
+


### PR DESCRIPTION
This is a bit of an opinionated, larger pull request, but I think it helps clean up the plugin a bit and adds support for pagination, in the case that more than 100 licenses are returned from the API.

Updates include:
- Updated Generate and List tabs on a single page to be broken out onto to separate sidebar tabs. With the addition of pagination support, breaking these behaviors into two separate tabs gives a bit more control over handling the two different scenarios.
- Added pagination support when listing plugin licenses (there is plenty of room for improvement here, but all plugin licenses can at least be seen now). This update also required an update to the `barrelstrength/craftnet-php` library which I've pushed up and released
- Various copy updates such as simplifying Label text and adding moving longer explanations to Instructions fields
- Various code cleanup and added support for Craft conventions using Craft form macros
- Various minor bugfixes

Let me know if I can provide anything else to explain the above. Feel free to reach out on Craft Slack if you'd like to discuss anything.