### PR TITLE
Adds command line tools and Licenses Model and Service layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Craftnet CP plugin for Craft CMS 3.x
 
-Basic craftnet integration with a CP interface. 
+Basic craftnet integration with a CP interface and command line tools. 
 
 Note that I made this mostly for myself and that future development will take place if and when I need it. Issues and PR's will be handled on a best-effort basis.
 
@@ -22,7 +22,6 @@ To install the plugin, follow these instructions.
 
 3. In the Control Panel, go to Settings → Plugins and click the “Install” button for Craftnet CP.
 
-
 ## Configuring Craftnet CP
 
 You can manage the following settings in your `craftnet-cp.php` file:
@@ -34,12 +33,51 @@ You can manage the following settings in your `craftnet-cp.php` file:
 
     <?php return [
         'username' => 'you@myawesomeplugins.com',
-        'token' => '5tmukfu4x2ld8xm1619oJy8klw17fvDsXsDDft8nk
+        'token' => '5tmukfu4x2ld8xm1619oJy8klw17fvDsXsDDft8nk'
         'plugins' => [
             'plugin-handle' => 'Plugin Label',
         ],
         'displayNotes' => true
     ];
+
+## Console Commands
+
+You can add licenses individually or in bulk from the command line.
+
+### craftnet-cp/license/generate
+
+```
+// Generate a single license
+./craft craftnet-cp/license/generate --email=customer@company.com --plugin=my-plugin-handle 
+
+// Generate a single license with more details
+./craft craftnet-cp/license/generate --email=customer@company.com --plugin=my-plugin-handle --edition=free --expirable=true --notes="Things to note." --privateNotes="Things to note."
+
+// Generate multiple licenses
+./craft craftnet-cp/license/generate --email=customer@company.com --plugin=my-plugin-handle --count=3
+```
+
+- The `edition` attribute defaults to `standard`
+- The `expirable` attribute defaults to `false`
+- The `count` attribute defaults to `1`
+
+### craftnet-cp/license/import-csv
+
+Add licenses in bulk via a CSV file. 
+
+```
+./craft craftnet-cp/license/import-csv --file="/path/to/file.csv"
+```
+
+CSV files can include the following column headers:
+
+- plugin
+- email
+- count
+- edition
+- expirable
+- notes
+- privateNotes
 
 ## Functionality
 

--- a/src/CraftnetCp.php
+++ b/src/CraftnetCp.php
@@ -19,6 +19,7 @@ use craft\events\PluginEvent;
 use craft\web\UrlManager;
 use craft\events\RegisterUrlRulesEvent;
 
+use studioespresso\craftnetcp\services\Licenses;
 use yii\base\Event;
 
 /**
@@ -55,6 +56,13 @@ class CraftnetCp extends Plugin
     // =========================================================================
 
     /**
+     * Licenses Service
+     *
+     * @var Licenses
+     */
+    public $licenses;
+
+    /**
      * To execute your plugin’s migrations, you’ll need to increase its schema version.
      *
      * @var string
@@ -79,6 +87,8 @@ class CraftnetCp extends Plugin
     {
         parent::init();
         self::$plugin = $this;
+
+        $this->licenses = new Licenses();
 
         // Register our CP routes
         Event::on(

--- a/src/console/controllers/LicenseController.php
+++ b/src/console/controllers/LicenseController.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * @link      https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license   https://craftcms.github.io/license/
+ */
+
+namespace studioespresso\craftnetcp\console\controllers;
+
+use Craft;
+use craft\helpers\Console;
+use craft\helpers\FileHelper;
+use studioespresso\craftnetcp\CraftnetCp;
+use studioespresso\craftnetcp\models\License;
+use yii\console\Controller;
+use yii\console\ExitCode;
+
+class LicenseController extends Controller
+{
+    /**
+     * @inheritdoc
+     */
+    public $defaultAction = 'generate-license';
+
+    public $email;
+    public $plugin;
+    public $edition;
+    public $expirable;
+    public $notes;
+    public $privateNotes;
+    public $count = 1;
+
+    public $file;
+
+    /**
+     * @inheritdoc
+     */
+    public function options($actionID)
+    {
+        $options = parent::options($actionID);
+
+        if ($actionID === 'generate') {
+            $options[] = 'email';
+            $options[] = 'plugin';
+            $options[] = 'edition';
+            $options[] = 'expirable';
+            $options[] = 'notes';
+            $options[] = 'privateNotes';
+            $options[] = 'count';
+        }
+
+        if ($actionID === 'import-csv') {
+            $options[] = 'file';
+        }
+
+        return $options;
+    }
+
+    /**
+     * Generate one or more licenses
+     */
+    public function actionGenerate()
+    {
+        if (!$this->email) {
+            $message = Craft::t("craftnet-cp", "Email attribute required");
+            $this->stdout($message);
+            return ExitCode::DATAERR;
+        }
+
+        if (!$this->plugin) {
+            $message = Craft::t("craftnet-cp", "Plugin Handle attribute required");
+            $this->stdout($message);
+            return ExitCode::DATAERR;
+        }
+
+        $license = new License();
+        $license->email = $this->email;
+        $license->plugin = $this->plugin;
+        $license->edition = $this->edition ?? 'standard';
+        $license->expirable = $this->expirable ?? false;
+        $license->notes = $this->notes ?? null;
+        $license->privateNotes = $this->privateNotes ?? null;
+        $license->privateNotes = $this->count;
+
+        $this->stdout(PHP_EOL.
+            "-- ".Craft::t('craftnet-cp', 'NEW LICENSE')." ----------------------------".PHP_EOL.
+            Craft::t('craftnet-cp', "Email: ").$license->email.PHP_EOL.
+            Craft::t('craftnet-cp', "Plugin: ").$license->plugin.PHP_EOL.
+            Craft::t('craftnet-cp', "Edition: ").$license->edition.PHP_EOL.
+            Craft::t('craftnet-cp', "Expirable: ").($license->expirable ? 'Yes' : 'No').PHP_EOL.
+            Craft::t('craftnet-cp', "Notes: ").$license->notes.PHP_EOL.
+            Craft::t('craftnet-cp', "Private Notes: ").$license->privateNotes.PHP_EOL.
+            "-------------------------------------------"
+            .PHP_EOL, Console::FG_GREY);
+
+        if (!$this->confirm(Craft::t('craftnet-cp', 'Generate {count} License(s)?', [
+            'count' => $this->count
+        ]))) {
+            $this->stdout(Craft::t('craftnet-cp', 'License generation cancelled.'), Console::FG_YELLOW);
+            return ExitCode::OK;
+        }
+
+        $this->stdout(Craft::t('craftnet-cp', 'Generating license via Craftnet API ... ').PHP_EOL, Console::FG_YELLOW);
+
+        // Create the license(s)
+        if (!CraftnetCp::$plugin->licenses->createLicense($license)) {
+            $this->stdout(Craft::t('craftnet-cp', 'Unable to create one or more licenses.').PHP_EOL, Console::FG_RED);
+            return ExitCode::DATAERR;
+        }
+
+        $this->stdout(Craft::t('craftnet-cp', 'License(s) created.').PHP_EOL, Console::FG_GREEN);
+        return ExitCode::OK;
+    }
+
+    /**
+     * Import a CSV file of licenses
+     */
+    public function actionImportCsv()
+    {
+        $rows = array_map('str_getcsv', file($this->file));
+
+        if (count($rows) <= 0) {
+            $this->stdout(Craft::t('craftnet-cp', 'No rows found in CSV file.'), Console::FG_YELLOW);
+            return ExitCode::OK;
+        }
+
+        $licenses = [];
+
+        // Grab the header row and remove it
+        $headerRows = $rows[0];
+        array_shift($rows);
+
+        // Update the array to be an associative array and update the keys to use the header row values
+        array_walk($rows, function(&$value, $key) use (&$licenses, $headerRows) {
+
+            $license = new License();
+
+            // Dynamically build the License model from our header row and data rows
+            foreach ($value as $index => $attribute) {
+                $license->{$headerRows[$index]} = $attribute;
+            }
+
+            $licenses[] = $license;
+        });
+        
+        foreach ($licenses as $license)
+        {
+            // Create the license(s)
+            if (!CraftnetCp::$plugin->licenses->createLicense($license)) {
+                $this->stdout(Craft::t('craftnet-cp', 'Unable to create ' . $license->count . ' ' . $license->plugin . ' license(s) for ' . $license->email . ' ').PHP_EOL, Console::FG_RED);
+            }
+
+            $this->stdout(Craft::t('craftnet-cp', 'Created ' . $license->count . ' ' . $license->plugin . ' license(s) for ' . $license->email . ' ').PHP_EOL, Console::FG_GREEN);
+        }
+
+        return ExitCode::OK;
+    }
+}

--- a/src/controllers/LicenseController.php
+++ b/src/controllers/LicenseController.php
@@ -15,6 +15,7 @@ use studioespresso\craftnetcp\CraftnetCp;
 
 use Craft;
 use craft\web\Controller;
+use studioespresso\craftnetcp\models\License;
 
 /**
  * License Controller
@@ -51,30 +52,28 @@ class LicenseController extends Controller
     // =========================================================================
     public function actionGenerate()
     {
-        $handle = Craft::$app->request->getRequiredBodyParam('handle');
-        $email = Craft::$app->request->getRequiredBodyParam('email');
-        $edition = Craft::$app->request->getBodyParam('edition') ? Craft::$app->request->getBodyParam('edition') : 'standard';
-        $expirable = Craft::$app->request->getBodyParam('expirable');
-        $notes = Craft::$app->request->getBodyParam('notes');
-        $privateNotes = Craft::$app->request->getBodyParam('privateNotes');
-        $count = Craft::$app->request->getBodyParam('count');
+        // License Info
+        $license = new License();
+        $license->plugin = Craft::$app->request->getRequiredBodyParam('handle');
+        $license->email = Craft::$app->request->getRequiredBodyParam('email');
+        $license->edition = Craft::$app->request->getBodyParam('edition') ? Craft::$app->request->getBodyParam('edition') : 'standard';
+        $license->expirable = Craft::$app->request->getBodyParam('expirable');
+        $license->notes = Craft::$app->request->getBodyParam('notes');
+        $license->privateNotes = Craft::$app->request->getBodyParam('privateNotes');
+        $license->count = Craft::$app->request->getBodyParam('count');
+        
+        if (!CraftnetCp::$plugin->licenses->createLicense($license))
+        {
+            $errorMessage = Craft::t('craftnet-cp', 'Unable to generate license(s)');
+            Craft::$app->getSession()->setError($errorMessage);
+            Craft::error($errorMessage);
 
-        $username = CraftnetCp::$plugin->getSettings()->username;
-        $apiKey = CraftnetCp::$plugin->getSettings()->token;
-        $client = new CraftnetClient($username, $apiKey);
-
-        for ($x = 1; $x <= $count; $x++) {
-            $response = $client->pluginLicenses->create([
-                'edition' => $edition,
-                'plugin' => $handle,
-                'email' => $email,
-                'notes' => $notes,
-                'expirable' => $expirable ? true : false,
-                'privateNotes' => $privateNotes
+            return Craft::$app->getUrlManager()->setRouteParams([
+                'license' => $license
             ]);
         }
 
-        Craft::$app->getSession()->setNotice('License generated');
+        Craft::$app->getSession()->setNotice('License(s) generated');
         return $this->redirectToPostedUrl();
     }
 

--- a/src/models/License.php
+++ b/src/models/License.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Craftnet CP plugin for Craft CMS 3.x
+ *
+ * Basic craft net integration with a CP interface
+ *
+ * @link      https://www.studioespresso.co
+ * @copyright Copyright (c) 2018 Studio Espresso
+ */
+
+namespace studioespresso\craftnetcp\models;
+
+use studioespresso\craftnetcp\CraftnetCp;
+
+use Craft;
+use craft\base\Model;
+
+/**
+ * CraftnetCp Settings Model
+ *
+ * This is a model used to define the plugin's settings.
+ *
+ * Models are containers for data. Just about every time information is passed
+ * between services, controllers, and templates in Craft, it’s passed via a model.
+ *
+ * https://craftcms.com/docs/plugins/models
+ *
+ * @author    Studio Espresso
+ * @package   CraftnetCp
+ * @since     1.0.0
+ */
+class License extends Model
+{
+    // Public Properties
+    // =========================================================================
+
+    /**
+     * @var string
+     */
+    public $email;
+
+    /**
+     * @var string
+     */
+    public $edition = 'standard';
+
+    public $plugin;
+
+    public $expirable = false;
+
+    public $notes;
+
+    public $privateNotes;
+
+    public $count = 1;
+
+    // Public Methods
+    // =========================================================================
+
+    /**
+     * @inheritdoc
+     */
+    public function rules()
+    {
+        return [
+            [['email', 'edition', 'plugin'], 'required'],
+        ];
+    }
+}
+

--- a/src/services/Licenses.php
+++ b/src/services/Licenses.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace studioespresso\craftnetcp\services;
+
+use barrelstrength\craftnetphp\CraftnetClient;
+use craft\base\Component;
+use Craft;
+use studioespresso\craftnetcp\CraftnetCp;
+use studioespresso\craftnetcp\models\License;
+
+class Licenses extends Component
+{
+    public function createLicense(License $license)
+    {
+        if ($license->count <= 0) {
+            return false;
+        }
+
+        // Client info
+        $username = CraftnetCp::$plugin->getSettings()->username;
+        $apiKey = CraftnetCp::$plugin->getSettings()->token;
+        $client = new CraftnetClient($username, $apiKey);
+
+        // Generate Licenses
+        for ($x = 1; $x <= $license->count; $x++) {
+            // @todo - potential bug, response will be overwritten each loop
+            $response = $client->pluginLicenses->create([
+                'edition' => $license->edition,
+                'plugin' => $license->plugin,
+                'email' => $license->email,
+                'notes' => $license->notes,
+                'expirable' => $license->expirable ? true : false,
+                'privateNotes' => $license->privateNotes
+            ]);
+        }
+
+        return $response;
+    }
+}


### PR DESCRIPTION
I had a need for a bulk license migration and added a few command line tools to help me out. In doing so, I abstracted the previous workflow driven by the web controller and introduced a License Model and Licenses Service so that the web and console controllers could both use the same API.

Admittedly, I have not over tested but the updates worked pretty well for me migrating all of our licenses from Straight Up Craft to Craft ID. Thought I'd share in case it's worth rolling in for others.

More details on the Console Commands here:
https://github.com/BenParizek/craft3-craftnet-cp#console-commands