### PR TITLE
Remove `displayNotes` + minor UI improvements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.3.0 - 2019-03-01
+### Added
+- Support for environment variables in control panel settings.
+### Changed
+- Improved listing Date display format.
+### Removed
+- Removed `displayNotes` setting, including notes within listing rows using info tooltip.
+
 ## 1.2.0 - 2018-09-10
 ### Added
 - Pagination & seperated tabs ([via BenParizek, #2](https://github.com/studioespresso/craft3-craftnet-cp/pull/2))

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "studioespresso/craftnet-cp",
     "description": "Basic craft net integration with a CP interface",
     "type": "craft-plugin",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "keywords": [
         "craft",
         "cms",

--- a/src/CraftnetCp.php
+++ b/src/CraftnetCp.php
@@ -155,7 +155,8 @@ class CraftnetCp extends Plugin
         return Craft::$app->view->renderTemplate(
             'craftnet-cp/settings',
             [
-                'settings' => $this->getSettings()
+                'settings'  => $this->getSettings(),
+                'isCraft31' => version_compare(Craft::$app->getVersion(), '3.1', '>='),
             ]
         );
     }

--- a/src/controllers/LicenseController.php
+++ b/src/controllers/LicenseController.php
@@ -61,7 +61,7 @@ class LicenseController extends Controller
 
         $username = CraftnetCp::$plugin->getSettings()->username;
         $apiKey = CraftnetCp::$plugin->getSettings()->token;
-        $client = new CraftnetClient($username, $apiKey);
+        $client = $this->_getCraftnetClient($username, $apiKey);
 
         for ($x = 1; $x <= $count; $x++) {
             $response = $client->pluginLicenses->create([
@@ -89,7 +89,7 @@ class LicenseController extends Controller
 
         $username = CraftnetCp::$plugin->getSettings()->username;
         $apiKey = CraftnetCp::$plugin->getSettings()->token;
-        $client = new CraftnetClient($username, $apiKey);
+        $client = $this->_getCraftnetClient($username, $apiKey);
 
         $response = $client->pluginLicenses->get([
             'page' => $page
@@ -102,7 +102,19 @@ class LicenseController extends Controller
         return $this->renderTemplate('craftnet-cp/list', [
             'data' => $results,
             'page' => $page,
-            'displayNotes' => CraftnetCp::$plugin->getSettings()->displayNotes
         ]);
+    }
+
+    /**
+     * Gets a configured instance of the Craftnet API Client
+     *
+     * @return CraftnetClient
+     */
+    private function _getCraftnetClient($username, $apiKey)
+    {
+        return new CraftnetClient(
+            Craft::parseEnv($username),
+            Craft::parseEnv($apiKey)
+        );
     }
 }

--- a/src/controllers/LicenseController.php
+++ b/src/controllers/LicenseController.php
@@ -112,9 +112,16 @@ class LicenseController extends Controller
      */
     private function _getCraftnetClient($username, $apiKey)
     {
-        return new CraftnetClient(
-            Craft::parseEnv($username),
-            Craft::parseEnv($apiKey)
-        );
+        $isCraft31 = version_compare(Craft::$app->getVersion(), '3.1', '>=');
+
+        if ($isCraft31)
+        {
+            return new CraftnetClient(
+                Craft::parseEnv($username),
+                Craft::parseEnv($apiKey)
+            );
+        }
+
+        return new CraftnetClient($username, $apiKey);
     }
 }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -43,8 +43,6 @@ class Settings extends Model
 
     public $plugins = [];
 
-    public $displayNotes = false;
-
     // Public Methods
     // =========================================================================
 

--- a/src/templates/list.twig
+++ b/src/templates/list.twig
@@ -16,7 +16,7 @@
 {% extends "_layouts/cp" %}
 {% import "_includes/forms" as forms %}
 
-{% set title = "Plugin licenses (" ~ data.total ~ ")" %}
+{% set title = "Plugin Licenses (" ~ data.total ~ ")" %}
 {% set selectedSubnavItem = 'list' %}
 
 {% set selectedTab = 'list' %}
@@ -60,6 +60,7 @@
                 <th scope="col">{{ 'Customer' }}</th>
                 <th scope="col">{{ 'Key' }}</th>
                 <th scope="col">{{ 'Date' }}</th>
+                <th scope="col">{{ 'Notes' }}</th>
             </tr></thead>
             <tbody>
             {% for sale in licenses %}
@@ -67,14 +68,14 @@
                     <td data-title="id"><code>{{ sale.id }}</code></td>
                     <td data-title="plugin">{{ sale.pluginHandle }}</td>
                     <td data-title="email">{{ sale.email }}</td>
-                    <td data-title="email"><code>{{ sale.key }}</code></td>
-                    <td data-title="date">{{ sale.dateCreated }}</td>
+                    <td data-title="key"><code>{{ sale.key }}</code></td>
+                    <td data-title="date">{{ sale.dateCreated | datetime('short') }}</td>
+                    <td data-title="notes">
+                        {% if sale.notes -%}
+                            <div class="info">{{ sale.notes }}</div>
+                        {%- endif %}
+                    </td>
                 </tr>
-                {% if displayNotes %}
-                    <tr>
-                       <td colspan="5" class="light">{{ "Notes:"|t('craftnet-cp') }}: {{ sale.notes }}</td>
-                    </tr>
-                {% endif %}
             {% endfor %}
             </tbody>
         </table>

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -15,7 +15,7 @@
 
 {% import "_includes/forms" as forms %}
 
-{{ forms.autosuggestField({
+{% set usernameFieldSettings = {
     label: 'Username',
     instructions: 'Your id.craftcms.com username',
     id: 'username',
@@ -23,15 +23,24 @@
     value: settings['username'],
     first: true,
     errors: settings.getErrors('username'),
-    suggestions: craft.cp.getEnvSuggestions(),
-}) }}
+} %}
 
-{{ forms.autosuggestField({
+{% set tokenFieldSettings = {
     label: 'API token',
     instructions: 'Generate your Craft ID API token <a href="https://id.craftcms.com/developer/settings" target="_blank" rel="noopener">here</a>',
     id: 'token',
     name: 'token',
     value: settings['token'],
     errors: settings.getErrors('token'),
-    suggestions: craft.cp.getEnvSuggestions(),
-}) }}
+} %}
+
+{% if isCraft31 %}
+    {% set usernameFieldSettings = usernameFieldSettings | merge({ suggestions: craft.cp.getEnvSuggestions() }) %}
+    {{ forms.autosuggestField(usernameFieldSettings) }}
+
+    {% set tokenFieldSettings = tokenFieldSettings | merge({ suggestions: craft.cp.getEnvSuggestions() }) %}
+    {{ forms.autosuggestField(tokenFieldSettings) }}
+{% else %}
+    {{ forms.textField(usernameFieldSettings) }}
+    {{ forms.passwordField(tokenFieldSettings) }}
+{% endif %}

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -15,20 +15,23 @@
 
 {% import "_includes/forms" as forms %}
 
-{{ forms.textField({
+{{ forms.autosuggestField({
     label: 'Username',
     instructions: 'Your id.craftcms.com username',
     id: 'username',
     name: 'username',
     value: settings['username'],
-    first: true
+    first: true,
+    errors: settings.getErrors('username'),
+    suggestions: craft.cp.getEnvSuggestions(),
 }) }}
 
-{{ forms.textField({
+{{ forms.autosuggestField({
     label: 'API token',
     instructions: 'Generate your Craft ID API token <a href="https://id.craftcms.com/developer/settings" target="_blank" rel="noopener">here</a>',
     id: 'token',
     name: 'token',
-    value: settings['token']
+    value: settings['token'],
+    errors: settings.getErrors('token'),
+    suggestions: craft.cp.getEnvSuggestions(),
 }) }}
-


### PR DESCRIPTION
Thanks for this plugin, Jan! I'm proposing a few minor changes here, along with a new minor version number since the settings model would change.

- Adds support for environment variables as control panel settings with `Craft::parseEnv()` and the new `autosuggest` field.
- Removes `displayNotes` and instead uses an info tooltip in table rows because a) there's no more expense/overhead seeing as notes are already part of the object and b) it'll be a little tidier than adding another row.
- Shrinks down the listing creation date slightly to make up for the space the new column occupies :)

<img width="1055" alt="screen shot 2019-03-01 at 7 43 24 pm" src="https://user-images.githubusercontent.com/2488775/53676679-ab4a3080-3c5a-11e9-952c-78ba1899878b.png">